### PR TITLE
fix basename of cwd as default fallback behaviour

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const path = require('path');
 const repo = require('git-repo-name');
 
 module.exports = cwd => {
-  return pkgname(cwd) || gitname(cwd) || path.basename(cwd);
+  return pkgname(cwd) || gitname(cwd) || path.basename(cwd || process.cwd());
 };
 
 function pkgname(cwd = '') {

--- a/test.js
+++ b/test.js
@@ -20,4 +20,16 @@ describe('project-name', function() {
   it('should return the name from a git config', function() {
     assert.equal(name('fixtures/foo'), 'foo');
   });
+
+  it('should fall back to path.basename(process.cwd())', function() {
+    const cwd = process.cwd();
+    try {
+      process.chdir('./fixtures/foo');
+      assert.equal(name(), 'foo');
+    } catch (error) {
+      throw error;
+    } finally {
+      process.chdir(cwd);
+    }
+  })
 });


### PR DESCRIPTION
Hello! Handy package. Been using it for a while. Thanks for refactoring the code recently. 😀

It looks like a breaking change was introduced and is now inconsistent with the README description.

When passing no `cwd` argument, inside a directory without `package.json` nor Git repo, an error is thrown by `path.basename(undefined)`.

This patch implements as per documentation and adds a test.